### PR TITLE
ci(mac): enable code signing of binary

### DIFF
--- a/.changes/unreleased/🔨 Refactor-20221202-135540.yaml
+++ b/.changes/unreleased/🔨 Refactor-20221202-135540.yaml
@@ -1,0 +1,11 @@
+kind: "\U0001F528 Refactor"
+body:
+  Mac binary signing is now performed with quill. As long as the p12 cert is available
+  (which is the pfx cert relabeled), goreleaser release process will now sign mac
+  binaries from a mac, windows, or Linux machind.
+time: 2022-12-02T13:55:40.58944-06:00
+custom:
+  azure-boards-workitemid-fixed: '475825'
+  azure-boards-workitemid-related: '448642'
+  github-contributor: sheldonhull
+  github-link: ''

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,142 @@
+---
+# INFO: Why is there a _v1 suffix on amd64 builds?  https://goreleaser.com/customization/build/#why-is-there-a-_v1-suffix-on-amd64-builds
+project_name: dsv
+dist: .artifacts/goreleaser
+env:
+  - GITHUB_TOKEN='null' # required to bypass check as this tool integrates heavily with those systems
+  - GITLAB_TOKEN=''
+  - GITEA_TOKEN=''
+  - LOCAL_DEBUGGING=
+  - QUILL_SIGN_P12=
+  - QUILL_SIGN_PASSWORD=
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: dsv-darwin
+    binary: dsv
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -s -w
+      - -X thy/version.Version={{ .Summary }}
+      - -X thy/version.GitCommit={{ .FullCommit }}
+      - -X thy/version.BuildDate={{ .CommitDate }}
+    goos: [darwin]
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        - cmd: quill sign "{{ .Path }}" --ad-hoc={{ .IsSnapshot }} -vv
+          env:
+            - QUILL_LOG_FILE=.cache/quill-{{ .Target }}.log
+            - QUILL_SIGN_P12={{ .Env.QUILL_SIGN_P12 }}
+            - QUILL_SIGN_P12_PASSWORD={{ .Env.QUILL_SIGN_PASSWORD }}
+  - id: dsv-linux
+    binary: dsv-{{ replace .Os "windows" "win" }}-{{ if eq .Arch "386" }}x86{{ else if eq .Arch "amd64" }}x64{{ else }}{{ .Arch }}{{end}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -s -w
+      - -X thy/version.Version={{ .Summary }}
+      - -X thy/version.GitCommit={{ .FullCommit }}
+      - -X thy/version.BuildDate={{ .CommitDate }}
+    goos: [linux]
+    goarch:
+      - amd64
+      - '386'
+  - id: dsv-windows
+    binary: dsv
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -s -w
+      - -X thy/version.Version={{ .Summary }}
+      - -X thy/version.GitCommit={{ .FullCommit }}
+      - -X thy/version.BuildDate={{ .CommitDate }}
+    goos: [windows]
+    goarch:
+      - amd64
+      - '386'
+archives:
+  # Name template is: 'dsv-{{ .Os }}-{{ .Arch }}',
+  # but we replace:
+  #     - "windows" with "win"
+  #     - "386" with "x86"
+  #     - "amd64" with "x64"
+  # Example: "dsv-windows-amd64.exe" -> "dsv-win-x64.exe"
+  - format: binary
+    name_template: dsv-{{ replace .Os "windows" "win" }}-{{ if eq .Arch "386" }}x86{{ else if eq .Arch "amd64" }}x64{{ else }}{{ .Arch }}{{end}}
+checksum:
+  name_template: '{{ .ProjectName }}-{{.Runtime.Goos}}-sha256.txt'
+  algorithm: sha256
+  disable: false
+  # ids:
+  #   - dsv-linux
+
+# signs:
+# - artifacts: checksum  # NOTE: Uses GPG to sign checksums by default
+# - id: signtool
+#   ids:
+#     - dsv-windows
+#   cmd: signtool
+#   args:
+#     [
+#       sign,
+#       /tr,
+#       http,
+#       //timestamp.digicert.com,
+#       /td,
+#       sha256,
+#       /fd,
+#       sha256,
+#       /sha1,
+#       668feb4178afea4d3c4ae833459b09c2bcf6b64e,
+#       '${artifact}',
+#     ]
+#   artifacts: binary
+# - id: codesign
+#   ids:
+#     - dsv-darwin
+#   cmd: codesign
+#   args: [-s, 'Thycotic Software', '${artifact}']
+#   artifacts: binary
+# - id: sign-darwin
+#   ids:
+#     - dsv-darwin
+#   cmd: quill
+#   args: [sign, '${artifact}']
+#   artifacts: binary
+
+release:
+  prerelease: auto
+  draft: true
+  mode: replace
+  skip_upload: false
+  replace_existing_draft: true
+  name_template: '{{.ProjectName}}-v{{.Version}}'
+
+sboms:
+  - artifacts: binary
+    documents:
+      - '${artifact}.{{.Runtime.Goos}}.spdx.sbom'
+changelog:
+  skip: false
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'CI & Chore'
+      regexp: "^.*(fix|chore|build)[(\\w)]*:+.*$"
+      order: 2
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^style:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ builds:
       - arm64
     hooks:
       post:
+        # Quill tool is installed in environment by aqua.
         - cmd: quill sign "{{ .Path }}" --ad-hoc={{ .IsSnapshot }} -vv
           env:
             - QUILL_LOG_FILE=.cache/quill-{{ .Target }}.log

--- a/docs/developer/code-signing.md
+++ b/docs/developer/code-signing.md
@@ -1,0 +1,42 @@
+# Code Signing
+
+This is automated as part of the build process via calls to Azure Pipelines.
+
+This doc captures any specific debugging or other helpful notes to work through any issues.
+
+## General Tooling
+
+A single linux based agent is all that is required to build and sign for cross-platform, due to the power of Go and some amazing community projects.
+
+- For mac signing: [Quill](https://github.com/anchore/quill) to allow signing and notarization of the binary without using a darwin based build system.
+- For windows & linux binary signing: [cosign](https://github.com/sigstore/cosign)
+
+## Mac Specific
+
+The following certs from Apple are required to sign correctly.
+To do this automatically on a Darwin based system just run `mage certs:init`.
+If the dates are incorrect, update this to the latest from this page [Apple Public Certificates](https://www.apple.com/certificateauthority/)
+
+- [AppleIncRootCertificate](https://www.apple.com/appleca/AppleIncRootCertificate.cer)
+- [Worldwide Developer Relations - G1 (Expiring 02/07/2023 21:48:47 UTC)](https://developer.apple.com/certificationauthority/AppleWWDRCA.cer)
+
+- On a darwin system, to get more helpful diagnostics on why a signature is invalid try: `codesign -vvv --deep --strict ./.artifacts/dsv`.
+- Use the spctl utility to determine if the software to be notarized will run with the system policies currently in effect: `spctl -vvv --assess --type exec ./.artifacts/dsv`
+
+For visually verifying signing you can install: `brew install whatsyoursign` and then run `open '/usr/local/Caskroom/whatsyoursign/2.0.1/WhatsYourSign Installer.app'` or whatever version you find.
+This will add a Finder button when right-clicking that is called "Signing Info" and provide a visual way to look at the signing information on a Mac system.
+
+### Mac Resource Links
+
+| Topic | Description |
+| [Troubleshooting Common Issues][common-issues] | Working through notarization issues |
+
+### Mac Error Notes
+
+- `CSSMERR_TP_NOT_TRUSTED` build error (and sometimes but less common, is it's Archive 'Share' or 'Submit' manifestation) is
+  the result of mistakenly modifying Trust Settings on one of your iOS Development-related certificates. [stack overflow answer][stack-error-help].
+  [Apple support answer][apple-support-error-help] also provides more help.
+
+[common-issues]: https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087735
+[stack-error-help]: https://stackoverflow.com/a/8766966/68698
+[apple-support-error-help]: https://developer.apple.com/library/archive/technotes/tn2250/_index.html#//apple_ref/doc/uid/DTS40009933-CH1-TNTAG19

--- a/docs/developer/code-signing.md
+++ b/docs/developer/code-signing.md
@@ -4,27 +4,36 @@ This is automated as part of the build process via calls to Azure Pipelines.
 
 This doc captures any specific debugging or other helpful notes to work through any issues.
 
+## How Do I Sign?
+
+If you have all the required certs setup, then you just run `mage release` and all of the required signing steps will be performed by goreleaser for all platforms.
+
 ## General Tooling
 
 A single linux based agent is all that is required to build and sign for cross-platform, due to the power of Go and some amazing community projects.
+You should be able to do this on any OS, but this is primarily tested in Darwin & run in CI on a Linux based agent.
 
 - For mac signing: [Quill](https://github.com/anchore/quill) to allow signing and notarization of the binary without using a darwin based build system.
 - For windows & linux binary signing: [cosign](https://github.com/sigstore/cosign)
 
 ## Mac Specific
 
-The following certs from Apple are required to sign correctly.
-To do this automatically on a Darwin based system just run `mage certs:init`.
-If the dates are incorrect, update this to the latest from this page [Apple Public Certificates](https://www.apple.com/certificateauthority/)
-
-- [AppleIncRootCertificate](https://www.apple.com/appleca/AppleIncRootCertificate.cer)
-- [Worldwide Developer Relations - G1 (Expiring 02/07/2023 21:48:47 UTC)](https://developer.apple.com/certificationauthority/AppleWWDRCA.cer)
+### Validation
 
 - On a darwin system, to get more helpful diagnostics on why a signature is invalid try: `codesign -vvv --deep --strict ./.artifacts/dsv`.
 - Use the spctl utility to determine if the software to be notarized will run with the system policies currently in effect: `spctl -vvv --assess --type exec ./.artifacts/dsv`
 
 For visually verifying signing you can install: `brew install whatsyoursign` and then run `open '/usr/local/Caskroom/whatsyoursign/2.0.1/WhatsYourSign Installer.app'` or whatever version you find.
 This will add a Finder button when right-clicking that is called "Signing Info" and provide a visual way to look at the signing information on a Mac system.
+
+### [DEPRECATED] Codesign
+
+The following notes are more specific to working with Apple certificate signing.
+
+The following certs from Apple are required to sign correctly.
+To do this automatically on a Darwin based system just run `mage certs:init`.
+
+If the dates are incorrect, update this to the latest from this page [Apple Public Certificates](https://www.apple.com/certificateauthority/) in `magefile/certs` to add it to the download and install list.
 
 ### Mac Resource Links
 

--- a/magefiles/certs/certs.mage_darwin.go
+++ b/magefiles/certs/certs.mage_darwin.go
@@ -1,0 +1,80 @@
+package certs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"github.com/pterm/pterm"
+	"github.com/sheldonhull/magetools/pkg/magetoolsutils"
+
+	"github.com/DelineaXPM/dsv-cli/magefiles/constants"
+)
+
+type Certs mg.Namespace
+
+// Init downloads and installs the required certs for signing binaries from Apple. See docs/developer/code-signing.md for more info on Mac local signing.
+func (Certs) Init() error {
+	magetoolsutils.CheckPtermDebug()
+	var err error
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	pterm.Debug.Printfln("homeDir: %s", homeDir)
+	pterm.Warning.Printfln("This might require interactive approval to allow this to proceed on Darwin based system")
+
+	certsToDownload := []struct {
+		URL      string // URL is the file to download.
+		FileName string // FileName is the name of the file to save the asset as.
+	}{
+		{URL: "https://www.apple.com/appleca/AppleIncRootCertificate.cer", FileName: "AppleIncRootCertificate.cer"},
+		{URL: "https://developer.apple.com/certificationauthority/AppleWWDRCA.cer", FileName: "AppleWWDRCA.cer"},
+	}
+	prog, _ := pterm.DefaultProgressbar.
+		WithTotal(len(certsToDownload)).
+		WithTitle("Downloading Certs").Start()
+
+	defer func() {
+		_, _ = prog.Stop()
+	}()
+
+	for _, cert := range certsToDownload {
+		targetFile := filepath.Join(constants.CacheDirectory, cert.FileName)
+		prog.Title = fmt.Sprintf("checking for %s", cert.FileName)
+		// Check if the file exists. If not download it, otherwise we'll just install it.
+		if _, err := os.Stat(targetFile); os.IsNotExist(err) {
+			// Download the file from the url
+			pterm.Debug.Printfln("Downloading %s to %s", cert.URL, targetFile)
+			err = sh.RunV("curl", "-o", targetFile, cert.URL)
+			if err != nil {
+				return err
+			}
+			pterm.Info.Printfln("downloading cert: %s", targetFile)
+		} else {
+			pterm.Success.Printfln("cert already downloaded: %s", targetFile)
+		}
+		prog.Title = "Installing Certs"
+		// Install the cert
+		err = sh.Run(
+			"security",
+			"add-trusted-cert",
+			"-d",
+			"-r",
+			"unspecified",
+			"-k",
+			filepath.Join(homeDir, "Library/Keychains/login.keychain-db"),
+			targetFile,
+		)
+		if err != nil {
+			return err
+		}
+		prog.Increment()
+	}
+
+	// If the cer
+	return nil
+}

--- a/magefiles/constants/constants.mage.go
+++ b/magefiles/constants/constants.mage.go
@@ -1,0 +1,14 @@
+package constants
+
+// Since we are dealing with builds, having a constants file until using a config input makes it easy.
+
+const (
+	// ArtifactDirectory is a directory containing artifacts for the project and shouldn't be committed to source.
+	ArtifactDirectory = ".artifacts"
+
+	// PermissionUserReadWriteExecute is the permissions for the artifact directory.
+	PermissionUserReadWriteExecute = 0o0700
+
+	// CacheDirectory is where the cache for the project is placed, ie artifacts that don't need to be rebuilt often.
+	CacheDirectory = ".cache"
+)

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -18,6 +18,8 @@ import (
 	_ "github.com/sheldonhull/magetools/gotools"
 	//mage:import
 	_ "github.com/sheldonhull/magetools/docgen"
+	//mage:import
+	_ "github.com/DelineaXPM/dsv-cli/magefiles/certs"
 )
 
 // relTime returns just a simple relative time humanized, without the "ago" suffix.


### PR DESCRIPTION
- Add steps for `quill` to sign the binary for macOS.
- This is cross platform, so now if you have the binary you can sign on mac, windows, or Linux, and it should be a valid macOS binary signing.