### PR TITLE
refactor(ci): resolve missing codecov by enabling codecov uploader for tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,3 +21,17 @@ ignore:
   - '.vscode'
   - '.devcontainer'
   - 'vendor'
+# For future possibilities with critical path options in codecov, as Go not yet supported - 2023-01-09 sheldonhull
+profiling:
+  critical_files_paths:
+    - commands/*
+    - auth/*
+    - errors/*
+    - format/*
+    - internal/*
+    - paths/*
+    - requests/*
+    - store/*
+    - utils/*
+    - vaultcli/*
+    - version/*

--- a/pipelines/templates/task-codecov.yml
+++ b/pipelines/templates/task-codecov.yml
@@ -1,0 +1,21 @@
+---
+parameters:
+  - name: workingDirectory
+    type: string
+    default: $(System.DefaultWorkingDirectory)
+  - name: CODECOV_TOKEN
+    type: string
+steps:
+  - bash: |
+      # improved codecov with signature verification
+      curl https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+      curl -Os https://uploader.codecov.io/latest/linux/codecov
+      curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+      curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+      gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+      shasum -a 256 -c codecov.SHA256SUM
+      chmod +x codecov
+      ./codecov -t ${{ parameters.CODECOV_TOKEN }}
+    workingDirectory: ${{ parameters.workingDirectory }}
+    displayName: codecov-upload
+    condition: ne(variables['Agent.OS'], 'Windows_NT')

--- a/pipelines/tests.end-to-end.azure-pipelines.yml
+++ b/pipelines/tests.end-to-end.azure-pipelines.yml
@@ -29,6 +29,7 @@ variables:
   - group: 'CLi-pipeline-variables' # TODO: replace with dsv cli calls
   - group: GITHUB # to avoid api rate issues
   - template: templates/vars.common.yml
+  - group: DSV-CLI-CODECOV # for uploading to codecov which generates a merged code coverage result from all different types of tests (unit, integration, end2end)
 jobs:
   - job: endtoendtest
     displayName: dsv-cli-endtoend-test
@@ -221,4 +222,7 @@ jobs:
           USER_NAME: $(USER_NAME)
           LOCAL_DOMAIN: $(LOCAL_DOMAIN)
           DEV_DOMAIN: $(DEV_DOMAIN)
-# TEMPLATE: TO DO - CODECOV REPORT
+  - template: templates/task-codecov.yml
+    parameters:
+      workingDirectory: ${{ parameters.workingDirectory }}/$(Build.Repository.Name)
+      CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/pipelines/tests.integration.azure-pipelines.yml
+++ b/pipelines/tests.integration.azure-pipelines.yml
@@ -29,7 +29,7 @@ variables:
   - group: 'CLi-pipeline-variables' # TODO: replace with dsv cli calls
   - group: GITHUB # to avoid api rate issues
   - template: templates/vars.common.yml
-
+  - group: DSV-CLI-CODECOV # for uploading to codecov which generates a merged code coverage result from all different types of tests (unit, integration, end2end)
 jobs:
   - job: integrationtest
     displayName: dsv-cli-integration-test
@@ -230,4 +230,7 @@ jobs:
 
           LOCAL_DOMAIN: $(LOCAL_DOMAIN)
           DEV_DOMAIN: $(DEV_DOMAIN)
-# TEMPLATE: TO DO - CODECOV REPORT
+  - template: templates/task-codecov.yml
+    parameters:
+      workingDirectory: ${{ parameters.workingDirectory }}/$(Build.Repository.Name)
+      CODECOV_TOKEN: $(CODECOV_TOKEN)


### PR DESCRIPTION
- Enable codecov uploader.
- This will merge all CI jobs codecoverage for a total results with no effort on our part.
- Using verified (checksum verification) uploader and secure based upload.

Related [AB#477049](https://thycotic.visualstudio.com/4a89362e-1361-424f-a291-a8f57c2a8991/_workitems/edit/477049), fixes [AB#480978](https://thycotic.visualstudio.com/4a89362e-1361-424f-a291-a8f57c2a8991/_workitems/edit/480978), fixes [AB#480979](https://thycotic.visualstudio.com/4a89362e-1361-424f-a291-a8f57c2a8991/_workitems/edit/480979)
