### PR TITLE
fix(magefiles): fix generating links to binaries

### DIFF
--- a/.changes/unreleased/🐛 Bug Fix-20230403-180523.yaml
+++ b/.changes/unreleased/🐛 Bug Fix-20230403-180523.yaml
@@ -1,0 +1,8 @@
+kind: "\U0001F41B Bug Fix"
+body: Fix the format of links to pre-built binaries.
+time: 2023-04-03T18:05:23.678794722+03:00
+custom:
+  azure-boards-workitemid-fixed: ''
+  azure-boards-workitemid-related: ''
+  github-contributor: andrii-zakurenyi
+  github-link: https://github.com/andrii-zakurenyi

--- a/docs/developer/release.md
+++ b/docs/developer/release.md
@@ -41,3 +41,15 @@ This version number will be used to set the version of the release, so the docs 
 - Run `snapcraft login`.
 - After login: `snapcraft export-login snapcraft-login` to create a file `snapcraft-login` for the login to use for CI purposes.
   Upload this as a secure file in Azure DevOps Secure file vault, or if using a shared team DSV Vault, place it in there (that's pending implementation as of 2023-01).
+
+### Version Prefix
+
+- Referencing the version number diretly (not assets), is done via `1.0.0` with no prefix.
+  - For example the latest version number in `cli-versions.json` would not have the prefix.
+  - [Scoop](https://github.com/DelineaXPM/scoop-bucket/blob/89cc09954d090f0e5421230db51f8eaa40b63e18/dsv-cli.json#L2) is the same with version not having a prefix.
+- Tags (per Go standard) include `v` prefix.
+  This is created by goreleaser github process automatically.
+- Assets:
+  - GitHub assets include `v` prefix like `v1.0.0`.
+  - Scoop & Brew use version number without prefix in version field, but the download assets uploaded to github do have prefix in the file name.
+- S3 asset folder prefers no `v` prefix.

--- a/magefiles/goreleaser.mage.custom.go
+++ b/magefiles/goreleaser.mage.custom.go
@@ -289,15 +289,16 @@ func (Release) GenerateCLIVersionFile() error {
 		Links  Links  `json:"links"`
 	}
 
+	ver := strings.TrimPrefix(releaseVersion, "v")
 	newJSON := cliVersions{
-		Latest: strings.TrimPrefix(releaseVersion, "v"),
+		Latest: ver,
 		Links: Links{
-			DarwinAmd64:  fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "darwin-x64"),
-			DarwinArm64:  fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "darwin-arm64"),
-			LinuxAmd64:   fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "linux-x64"),
-			Linux386:     fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "linux-x86"),
-			WindowsAmd64: fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "windows-x64"),
-			Windows386:   fmt.Sprintf(constants.DownloadURLFString, releaseVersion, "windows-x86"),
+			DarwinAmd64:  fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-darwin-x64"),
+			DarwinArm64:  fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-darwin-arm64"),
+			LinuxAmd64:   fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-linux-x64"),
+			Linux386:     fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-linux-x86"),
+			WindowsAmd64: fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-windows-x64.exe"),
+			Windows386:   fmt.Sprintf(constants.DownloadURLFString, ver, "dsv-windows-x86.exe"),
 		},
 	}
 


### PR DESCRIPTION
CLI reports that download available at:

```text
<...> download available at https://dsv.secretsvaultcloud.com/downloads/cli/v1.40.2/linux-x64
```

but correct URL for download is:

```text
<...> download available at https://dsv.secretsvaultcloud.com/downloads/cli/1.40.2/dsv-linux-x64
```

Fixes #89 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 48c520a</samp>

### Summary
🐛📝🧹

<!--
1.  🐛 for the bug fix in the YAML file and the `GenerateCLIVersionFile` function.
2.  📝 for the documentation update in the `release.md` file.
3.  🧹 for the code cleanup and simplification in the `GenerateCLIVersionFile` function.
-->
This pull request fixes the link formats to the pre-built binaries of the dsv-cli tool and adds documentation for the version prefix conventions. It also refactors the `GenerateCLIVersionFile` function in the `magefiles/goreleaser.mage.custom.go` file to improve readability and consistency.

> _Fixing `dsv-cli`_
> _Links to binaries_
> _Autumn of bugs is over_

### Walkthrough
* Fix the format of links to pre-built binaries of the dsv-cli tool in the JSON file and the YAML file ([link](https://github.com/DelineaXPM/dsv-cli/pull/90/files?diff=unified&w=0#diff-ec3080eae9ed55a40daa53a41997d1da3c606f91389c8eb1b683251367ddcc32R1-R8), [link](https://github.com/DelineaXPM/dsv-cli/pull/90/files?diff=unified&w=0#diff-c076ce5fd2767f4796c430f188621763ef386e733171e2f719fa9312c414a91cL292-R301))
* Document the version prefix conventions for different platforms and sources of the dsv-cli tool in the `docs/developer/release.md` file ([link](https://github.com/DelineaXPM/dsv-cli/pull/90/files?diff=unified&w=0#diff-865e5a986a0232a5df8d10e2bcbe0d20b68ceaf4f0d9f5d10c9b7a3881b06c62R44-R55))

